### PR TITLE
Fix default matcher for box: match / for box only when it's a prefix for something

### DIFF
--- a/syntrax.py
+++ b/syntrax.py
@@ -151,7 +151,7 @@ class DrawStyle(object):
     if len(node_styles) == 0:
       node_styles = [
         ('bubble', {'shape':'bubble', 'pattern':'^\w', 'font':('Sans', 14, 'bold'), 'fill':(179, 229, 252)}),
-        ('box', {'shape':'box', 'pattern':'^/', 'font':('Times', 14, 'italic'),
+        ('box', {'shape':'box', 'pattern':'^/.', 'font':('Times', 14, 'italic'),
                 'fill':(144, 164, 174), 'text_mod':'lambda txt: txt[1:]'}),
         ('token', {'shape':'bubble', 'pattern':'.', 'font':('Sans', 16, 'bold'), 'fill':(179, 229, 252)}),
       ]


### PR DESCRIPTION
Hi, first of all -- thanks for the great tool! Currently I'm migrating from `parcon.railroad` to `syntrax` for my project's documentation (which involves a custom SQL dialect description). 

There is an issue #2 -- it's not only me who came across the difficulty to get `'/'` node to be shown correctly as a simple token.

Let me offer the better solution than it was discussed in the issue. Since `'/'`-as-a-prefix should work only if something follows it, it seems that 'box' matcher should be fixed to `^/.`, that is 'beginning of a string, '/', and at least one character more'. Then we save the same behaviour for the '/' prefix, except only for a case when it stands alone -- for which `token` rule will work.